### PR TITLE
Add landing page and auth page

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Qanta - Authentification</title>
+    <link rel="apple-touch-icon" href="./img/qantaLogo.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./img/appicon.png">
+    <link rel="apple-touch-icon" href="/img/qanta-180.png">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="auth-wrapper fade-in">
+        <h2>Connexion</h2>
+        <form>
+            <input type="text" placeholder="Nom d'utilisateur" required />
+            <input type="password" placeholder="Mot de passe" required />
+            <button type="submit" class="btn">Se connecter</button>
+        </form>
+        <a href="home.html" class="btn secondary">Retour</a>
+    </div>
+
+    <footer class="footer">
+        <p>Crafted by <strong>Mad Cre@tive Lab</strong></p>
+    </footer>
+</body>
+</html>

--- a/home.html
+++ b/home.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Qanta - Home</title>
+    <link rel="apple-touch-icon" href="./img/qantaLogo.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./img/appicon.png">
+    <link rel="apple-touch-icon" href="/img/qanta-180.png">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="home-wrapper fade-in">
+        <img src="./img/appicon.png" alt="Qanta Logo" class="hero-logo" width="200" />
+        <h1 class="intro-text">Bienvenue sur Qanta</h1>
+        <p class="subtitle">Votre messagerie PWA simple et rapide</p>
+        <div class="home-actions">
+            <a href="auth.html" class="btn">Authentification</a>
+            <a href="index.html" class="btn secondary">Accéder au Chat</a>
+        </div>
+    </div>
+
+    <footer class="footer">
+        <p>Crafted by <strong>Mad Cre@tive Lab</strong></p>
+    </footer>
+
+    <script>
+        const text = document.querySelector('.intro-text');
+        let index = 0;
+        const original = text.textContent;
+        text.textContent = '';
+        function type() {
+            if (index < original.length) {
+                text.textContent += original.charAt(index);
+                index++;
+                setTimeout(type, 100);
+            }
+        }
+        window.onload = type;
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 
     </div>
     <footer class="footer">
-        <p>Crafted by <strong>Mad Cre@tive Lab</strong></p>
+        <p>Crafted by <strong>Mad Cre@tive Lab</strong> - <a href="home.html">Accueil</a></p>
       </footer>
     <script src="app.js"></script>
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
  {
     "name": "Qanta",
     "short_name": "Qanta",
-    "start_url": "/",
+    "start_url": "/home.html",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#075e54",

--- a/service-worker.js
+++ b/service-worker.js
@@ -8,15 +8,16 @@
 const CACHE_NAME = 'whatsapp-clone-cache-v1';
 const urlsToCache = [
     '/',
+    '/home.html',
     '/index.html',
+    '/auth.html',
     '/style.css',
     '/app.js',
-    '/appicon.png',
     '/appicon.png',
     '/img/qanta-192.png',
     '/img/qanta-512.png',
     '/manifest.json'
-    
+
 ];
 
 self.addEventListener('install', (event) => {

--- a/style.css
+++ b/style.css
@@ -191,3 +191,72 @@ main {
 
 
 
+
+/* Home and Authentication Styling */
+.home-wrapper, .auth-wrapper {
+    width: 100%;
+    max-width: 400px;
+    text-align: center;
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 30px 20px;
+    border-radius: 20px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+.hero-logo {
+    margin-bottom: 20px;
+}
+
+.subtitle {
+    margin-top: 5px;
+    color: #075e54;
+}
+
+.home-actions {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 10px 20px;
+    text-decoration: none;
+    color: #ffffff;
+    background-color: #34b5f1;
+    border-radius: 5px;
+}
+
+.btn.secondary {
+    background-color: #b9a3f7;
+    color: #000;
+}
+
+.btn:hover {
+    opacity: 0.9;
+}
+
+.fade-in {
+    animation: fadeIn 1s ease-in forwards;
+    opacity: 0;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.auth-wrapper form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.auth-wrapper input {
+    padding: 10px;
+    border-radius: 5px;
+    border: 1px solid #cccccc;
+}
+


### PR DESCRIPTION
## Summary
- add `home.html` landing page with intro animation
- add `auth.html` placeholder authentication page
- link chat page footer back to home
- cache new pages and update PWA manifest
- style home and auth pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842d833ef288330a4e4526043761ce2